### PR TITLE
Task. 9-5 既存 API の修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,6 +1,9 @@
 module Api::V1
   # base_api_controller を継承
   class ArticlesController < BaseApiController
+    # current_userでユーザー情報を取得できる
+    before_action :authenticate_user!, only: [:create, :update, :destroy]
+
     def create
       article = current_user.articles.create!(article_params)
       render json: article, serializer: Api::V1::ArticleSerializer

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::BaseApiController < ApplicationController
-  def current_user
-    @current_user ||= User.first
-  end
+  # alias_method（別名をつける） 新メソッド名, 旧メソッド名
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -46,12 +46,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "POST /articles" do
-    subject { post(api_v1_articles_path, params: params) }
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
 
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
-
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) { current_user.create_new_auth_token }
 
     it "記事の作成に成功する" do
       expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
@@ -63,11 +62,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "PATCH api/v1/articles/:id" do
-    subject { patch(api_v1_article_path(article.id), params: params) }
+    subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
 
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) { current_user.create_new_auth_token }
 
     context "記事のレコードを更新するとき" do
       let(:article) { create(:article, user: current_user) }
@@ -91,11 +90,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "DELETE articles/:id" do
-    subject { delete(api_v1_article_path(article.id)) }
+    subject { delete(api_v1_article_path(article.id), headers: headers) }
 
     let(:current_user) { create(:user) }
     let(:article_id) { article.id }
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) { current_user.create_new_auth_token }
 
     context "任意の記事を削除するとき" do
       let!(:article) { create(:article, user: current_user) }


### PR DESCRIPTION
## 概要
- base_api_controller のダミーコードである current_user メソッド を削除
- base_api_controller で devise_token_auth で提供されている各種メソッド実装（ current_user, authenticate_user!, user_signed_in? ）
- ログインしていないと使えない API は authenticate_user! で弾くように実装