### PR TITLE
herokuデプロイに伴う修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,7 +81,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(stdout)
+    logger           = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end


### PR DESCRIPTION
- production.rbの修正
  ┗以前rubocop実行時エラーに伴い修正を行なっていた内容が間違っていたため。